### PR TITLE
Moved S3 bucket name to configuration

### DIFF
--- a/heimdall.google-addon/JenkinsServerConnector.js
+++ b/heimdall.google-addon/JenkinsServerConnector.js
@@ -155,7 +155,7 @@ function getAllBuildCollection() {
 //TODO: Provide IAM role implementation
 function getStatusFromS3(buildNumber) {
     Logger.log("get status from s3")
-    var bucketName = "miq-qa-test-status";
+    userProperties.getProperty("s3BucketName");
     var jenkinsDomain = userProperties.getProperty("jenkinsDomain");
     var url = jenkinsDomain + "/job/" + jenkinsJobName + "/" + buildNumber + "/console";
     var note = "Test Results not found in S3";

--- a/heimdall.google-addon/S3.js
+++ b/heimdall.google-addon/S3.js
@@ -43,7 +43,9 @@ S3.prototype.getObject = function (bucket, objectName, options) {
     request.setHttpMethod('GET');
     request.setContentType('application/json')
     request.setBucket(bucket);
-    if (typeof bucket !== 'string') SpreadsheetApp.getUi().alert('Pass valid bucket name');
+    if (typeof bucket !== 'string'){
+         SpreadsheetApp.getUi().alert('Pass valid bucket name');
+    }
     request.setObjectName(objectName);
     try {
         var responseBlob = request.execute(options).getBlob();

--- a/heimdall.google-addon/S3.js
+++ b/heimdall.google-addon/S3.js
@@ -43,6 +43,7 @@ S3.prototype.getObject = function (bucket, objectName, options) {
     request.setHttpMethod('GET');
     request.setContentType('application/json')
     request.setBucket(bucket);
+    if (typeof bucket !== 'string') SpreadsheetApp.getUi().alert('Pass valid bucket name');
     request.setObjectName(objectName);
     try {
         var responseBlob = request.execute(options).getBlob();

--- a/heimdall.google-addon/config.html
+++ b/heimdall.google-addon/config.html
@@ -26,6 +26,7 @@
           document.getElementById("jenkinsJobCategory").value = obj.jenkinsJobCategory;
           document.getElementById("s3AccessKey").value = obj.s3AccessKey;
           document.getElementById("s3SecretKey").value = obj.s3SecretKey;
+          document.getElementById("s3BucketName").value = obj.s3BucketName;
        }).getAuthValues();
        closeHelp();
    }
@@ -37,13 +38,15 @@
      var jenkinsJobCategory = $("#jenkinsJobCategory").val();
      var s3AccessKey =  $("#s3AccessKey").val();
      var s3SecretKey = $("#s3SecretKey").val();
+     var s3BucketName = $("#s3BucketName").val();
      var auth = {
        tokenName: tokenName,
        tokenId: tokenId,
        jenkinsDomain: jenkinsDomain,
        jenkinsJobCategory: jenkinsJobCategory,
        s3AccessKey: s3AccessKey,
-       s3SecretKey: s3SecretKey
+       s3SecretKey: s3SecretKey,
+       s3BucketName : s3BucketName
      }
      google.script.run.getAuthenticationValues(auth); 
      closeHelp();
@@ -71,6 +74,10 @@
             <label>Jenkins Job Category</label>
             <input type="text" class="form-control" id="jenkinsJobCategory"
                    placeholder="Enter Job Category">
+        </div>
+        <div class="form-group">
+            <label>S3 Bucket Name</label>
++           <input type="text" class="form-control" id="s3BucketName" placeholder="Enter S3 Bucket Name">
         </div>
         <div class="form-group">
             <label>S3 Access Key</label>

--- a/heimdall.google-addon/config.html
+++ b/heimdall.google-addon/config.html
@@ -77,7 +77,7 @@
         </div>
         <div class="form-group">
             <label>S3 Bucket Name</label>
-+           <input type="text" class="form-control" id="s3BucketName" placeholder="Enter S3 Bucket Name">
+           <input type="text" class="form-control" id="s3BucketName" placeholder="Enter S3 Bucket Name">
         </div>
         <div class="form-group">
             <label>S3 Access Key</label>


### PR DESCRIPTION
**Heimdall** helps to run the tests through the google spreadsheets. It stores the result in the S3 location.
The organization using the Heimdall can provide the **s3 bucket name** in the **configuration** to which they need to store the results. 
Previously this option was not available. After the modification, the user can specify the s3 location to which they need to store the test results.
![heimdall-github](https://user-images.githubusercontent.com/37182040/81525375-1cfb2f80-9372-11ea-8145-fc320113d828.PNG)

